### PR TITLE
Fix missing new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Among other functionalities, Kiwi Browser supports:
  - Night Mode (another implementation than Chromium)
  - Support for Chrome Extensions
  - Bottom address bar
+
 It also includes performance improvements (partial rasterization of tiles, etc)
 
 The browser is licensed under the same license as Chromium, which means that you are allowed to create derivatives of the browser.


### PR DESCRIPTION
There was a missing new line after the list of features in the README which caused the sentence `It also includes performance improvements (partial rasterization of tiles, etc)` to be rendered on the same line as the last list item `Bottom address bar`.