### PR TITLE
This change enables client certificate authentication on the browser.

### DIFF
--- a/chrome/browser/about_flags.cc
+++ b/chrome/browser/about_flags.cc
@@ -3895,7 +3895,13 @@ const FeatureEntry kFeatureEntries[] = {
      flag_descriptions::kLongPressBackForHistoryName,
      flag_descriptions::kLongPressBackForHistoryDescription, kOsAndroid,
      FEATURE_VALUE_TYPE(chrome::android::kLongPressBackForHistory)},
+
+	{"use-client-cert",
+	 flag_descriptions::kUseClientCertName,
+	 flag_descriptions::kUseClientCertDescription, kOsAndroid,
+	 FEATURE_VALUE_TYPE(chrome::android::kUseClientCert)},
 #endif
+
     // NOTE: Adding a new flag requires adding a corresponding entry to enum
     // "LoginCustomFlags" in tools/metrics/histograms/enums.xml. See "Flag
     // Histograms" in tools/metrics/histograms/README.md (run the

--- a/chrome/browser/android/chrome_feature_list.cc
+++ b/chrome/browser/android/chrome_feature_list.cc
@@ -353,6 +353,9 @@ const base::Feature kTabReparenting{"TabReparenting",
 const base::Feature kTrustedWebActivity{"TrustedWebActivity",
                                         base::FEATURE_ENABLED_BY_DEFAULT};
 
+const base::Feature kUseClientCert{"UseClientCertificates",
+                                             base::FEATURE_DISABLED_BY_DEFAULT};
+
 const base::Feature kUserMediaScreenCapturing{
     "UserMediaScreenCapturing", base::FEATURE_DISABLED_BY_DEFAULT};
 

--- a/chrome/browser/android/chrome_feature_list.h
+++ b/chrome/browser/android/chrome_feature_list.h
@@ -73,6 +73,7 @@ extern const base::Feature kSpecialLocaleWrapper;
 extern const base::Feature kTabModalJsDialog;
 extern const base::Feature kTabReparenting;
 extern const base::Feature kTrustedWebActivity;
+extern const base::Feature kUseClientCert;
 extern const base::Feature kUserMediaScreenCapturing;
 extern const base::Feature kVideoPersistence;
 extern const base::Feature kVrBrowsingFeedback;

--- a/chrome/browser/chrome_content_browser_client.cc
+++ b/chrome/browser/chrome_content_browser_client.cc
@@ -316,6 +316,7 @@
 #include "base/android/application_status_listener.h"
 #include "chrome/browser/android/app_hooks.h"
 #include "chrome/browser/android/chrome_context_util.h"
+#include "chrome/browser/android/chrome_feature_list.h"
 #include "chrome/browser/android/devtools_manager_delegate_android.h"
 #include "chrome/browser/android/download/intercept_oma_download_navigation_throttle.h"
 #include "chrome/browser/android/ntp/new_tab_page_url_handler.h"
@@ -2577,14 +2578,17 @@ void ChromeContentBrowserClient::SelectClientCertificate(
         prerender::FINAL_STATUS_SSL_CLIENT_CERTIFICATE_REQUESTED);
     return;
   }
-  if (true) {
-    LOG(WARNING) << "No client cert matched by policy and user selection is "
-                    "not allowed.";
-    // Continue without client certificate. We do this to mimic the case of no
-    // client certificate being present in the profile's certificate store.
-    delegate->ContinueWithCertificate(nullptr, nullptr);
-    return;
+
+#if defined(OS_ANDROID)
+  if (!base::FeatureList::IsEnabled(chrome::android::kUseClientCert)) {
+	  LOG(WARNING) << "No client cert matched by policy and user selection is "
+	                      "not allowed.";
+	  // Continue without client certificate. We do this to mimic the case of no
+	  // client certificate being present in the profile's certificate store.
+	  delegate->ContinueWithCertificate(nullptr, nullptr);
+	  return;
   }
+#endif
 
   GURL requesting_url("https://" + cert_request_info->host_and_port.ToString());
   DCHECK(requesting_url.is_valid())

--- a/chrome/browser/flag_descriptions.cc
+++ b/chrome/browser/flag_descriptions.cc
@@ -2404,6 +2404,11 @@ const char kSiteExplorationUiName[] = "Site Exploration UI";
 const char kSiteExplorationUiDescription[] =
     "Show site suggestions in the Exploration UI";
 
+const char kUseClientCertName[] = "Use Client Certificates";
+const char kUseClientCertDescription[] =
+    "When enabled, the system's client certificate selection dialog will be "
+	"shown when a https request requires client authentication";
+
 const char kUpdateMenuBadgeName[] = "Force show update menu badge";
 const char kUpdateMenuBadgeDescription[] =
     "When enabled, an update badge will be shown on the app menu button.";

--- a/chrome/browser/flag_descriptions.h
+++ b/chrome/browser/flag_descriptions.h
@@ -1453,6 +1453,9 @@ extern const char kSimplifiedNtpDescription[];
 extern const char kSiteExplorationUiName[];
 extern const char kSiteExplorationUiDescription[];
 
+extern const char kUseClientCertName[];
+extern const char kUseClientCertDescription[];
+
 extern const char kSpannableInlineAutocompleteName[];
 extern const char kSpannableInlineAutocompleteDescription[];
 


### PR DESCRIPTION
Before this change user certificate selection was disabled by default.
This change adds the feature "use-client-cert" in "chrome://flags" on
kiwi Browser for Android. "use-client-cert" feature is disabled by
default, but enabling this feature in "chrome://flags" the system's
user certificate selection dialog will be shown when a https server
ask for a client certificate.