### PR TITLE
Remove issues link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ If there is an issue or bug that you want to be included to Kiwi, please open an
 
 ## Additional help
 
-You can ask for extra help in our Discord server, or by [filing an issue](https://github.com/kiwibrowser/src/issues).
+You can ask for extra help in our Discord server:
 
 <a href="https://discord.gg/XyMppQq"> <img src="https://discordapp.com/assets/e4923594e694a21542a489471ecffa50.svg" height="50"></a>
 


### PR DESCRIPTION
The readme was telling people to file an issue which is currently not possible as the tab for those does not exist on this repo.

While I do think that the proper fix for this would be to re-enable the issues tab, I've removed the broken link from the readme for now.

Really, this is just my way of submitting an issue about how you can't submit issues anymore.